### PR TITLE
Resolve ClassCastException in getOrElseUpdate

### DIFF
--- a/src/main/scala/overlock/atomicmap/AtomicMap.scala
+++ b/src/main/scala/overlock/atomicmap/AtomicMap.scala
@@ -77,7 +77,7 @@ class AtomicMap[A,B](u : => JConcurrentMap[A,Any]) extends ConcurrentMap[A,B] {
             under.remove(key, t)
             throw ex
         }
-      case OneShotThunk(v : B) => v
+      case thunk : OneShotThunk[B] => thunk.value
       case v : B => v
     }
   }


### PR DESCRIPTION
Resolve ClassCastException: "String cannot be cast to scala.runtime.Nothing$" resulting when putIfAbsent returns a non-null value, triggering a match fall-through and improper type inference of "Nothing" by explicitly matching on type OneShotThunk[B] and forcing evaluation of the thunk on return.

Issue appears to have been introduced by: https://github.com/boundary/overlock/commit/5c79d195e512d3db80b9816918ca4421c4482a2b#L0L78

[ Original output of "throughput" test triggering issue: https://gist.github.com/960867 ]
