### PR TITLE
Add syntax for tryLock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,32 +130,7 @@
           </excludes>
         </configuration>
       </plugin>
-
-<!--      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>1.4</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-              </transformers>
-              <artifactSet>
-                <excludes>
-                  <exclude>org.scala-lang:scala-library</exclude>                  
-                  <exclude>junit:junit</exclude>
-                </excludes>
-              </artifactSet>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin> -->
-      
+     
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/src/main/scala/overlock/lock/Lock.scala
+++ b/src/main/scala/overlock/lock/Lock.scala
@@ -73,6 +73,8 @@ sealed class LockResult(private val success: Boolean) {
       f
     }
   }
+
+  def get: Boolean = success
 }
 
 object LockResult {

--- a/src/main/scala/overlock/lock/Lock.scala
+++ b/src/main/scala/overlock/lock/Lock.scala
@@ -37,4 +37,46 @@ class Lock {
       lock.writeLock.unlock
     }
   }
+
+  def tryLock[T](f : => T) : LockResult = tryWriteLock(f)
+
+  def tryReadLock[T](f : => T) : LockResult = {
+    if (lock.readLock().tryLock()) {
+      try {
+        f
+        LockResult.TRUE
+      } finally {
+        lock.readLock.unlock
+      }
+    } else {
+      LockResult.FALSE
+    }
+  }
+
+  def tryWriteLock[T](f : => T) : LockResult = {
+    if (lock.writeLock().tryLock()) {
+      try {
+        f
+        LockResult.TRUE
+      } finally {
+        lock.writeLock.unlock
+      }
+    } else {
+      LockResult.FALSE
+    }
+  }
 }
+
+sealed class LockResult(private val success: Boolean) {
+  def orElse[U](f : => U) {
+    if (!success) {
+      f
+    }
+  }
+}
+
+object LockResult {
+  val TRUE = new LockResult(true)
+  val FALSE = new LockResult(false)
+}
+

--- a/src/test/scala/overlock/lock/LockSpec.scala
+++ b/src/test/scala/overlock/lock/LockSpec.scala
@@ -1,0 +1,101 @@
+package overlock.lock
+
+import org.specs._
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+
+class LockSpec extends SpecificationWithJUnit {
+  "Lock" should {
+    "acquire a lock with tryLock if it's not already held" in {
+      val lock = new Lock
+
+      lock.tryWriteLock {
+        true must beTrue
+      }.orElse {
+        fail("Welp. You should have locked.")
+      }
+    }
+
+    "not acquire a lock with tryLock if it's already held" in {
+      val done = new AtomicBoolean(false)
+      val lock = new Lock
+      val holdUp = new CountDownLatch(1)
+
+      val dontLetGo = new Thread {
+        override def run() {
+          lock.writeLock {
+            holdUp.countDown()
+            while (!done.get()) { /*do nothing*/ }
+          }
+        }
+      }
+      dontLetGo.start()
+      holdUp.await()
+
+      try {
+        lock.tryWriteLock {
+          fail("Shouldn't be able to get here")
+        }.orElse {
+          true must beTrue
+        }
+      } finally {
+        done.set(true)
+      }
+    }
+
+    "be able to be held by multiple readers" in {
+      val numReaders = 5
+      val done = new AtomicBoolean(false)
+      val holdUp = new CountDownLatch(numReaders)
+      val lock = new Lock
+
+      val readers =
+        for (n <- 0 until numReaders) yield new Thread {
+          override def run() {
+            lock.tryReadLock {
+              holdUp.countDown()
+              while (!done.get) { /*spin, spin, spin*/}
+            }.orElse {
+              fail("I want to lock but it didn't let me")
+            }
+          }
+        }
+
+      readers.foreach(t => t.start())
+      holdUp.await()
+      lock.tryWriteLock {
+        fail("Shouldn't be able to write lock")
+      }.orElse {
+        // Success
+        true must beTrue
+      }
+    }
+
+    "be able to held by a single writer" in {
+      val holdUp = new CountDownLatch(1)
+      val done = new AtomicBoolean(false)
+      val lock = new Lock
+
+      val writer = new Thread {
+        override def run() {
+          lock.tryWriteLock {
+            holdUp.countDown()
+            while (!done.get) { /*keep on swimming, keep on swimming*/ }
+          }.orElse {
+            fail("Couldn't acquire a write lock")
+          }
+        }
+      }
+
+      writer.start()
+      holdUp.await()
+
+      lock.tryReadLock {
+        fail("Shouldn't be able to acquire a read lock while writing")
+      }.orElse {
+        // Great Success!
+        true must beTrue
+      }
+    }
+  }
+}


### PR DESCRIPTION
I added some syntax into Lock for making calls to `tryLock` on the underlying reader/writer locks. For simplicity, the call is made with the non-blocking [version](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/locks/Lock.html#tryLock(\)) of the `tryLock` method.

Trying to lock returns a success/failure object, and provides some DSL-style syntax for doing something in the event that you failed to acquire the lock you were after.

In practice, this looks like:

``` scala
lock.tryWriteLock {
   // Do some writing here
}.orElse {
  log.warn("Failed to lock!")
   // Sad trombones
}
```

There's also a commit that cleans out the commented-out shade plugin.
