### PR TITLE
Switch from logula to slf4j for logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ project/boot/*
 project/build/target/*
 target/*
 lib_managed/*
+.idea/
 *.iml
 *.ipr
 *.iws

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.boundary</groupId>
   <artifactId>overlock-scala_2.9.1</artifactId>
-  <version>0.8.2</version>
+  <version>0.8.3-SNAPSHOT</version>
 
   <name>overlock</name>
   <url>http://www.boundary.com</url>
@@ -19,17 +19,12 @@
     <dependency>
       <groupId>com.yammer.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>2.0.3</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>
       <artifactId>metrics-scala_${scala.version}</artifactId>
-      <version>2.0.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.codahale</groupId>
-      <artifactId>logula_${scala.version}</artifactId>
-      <version>2.1.3</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.boundary</groupId>
@@ -51,6 +46,17 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -178,29 +184,9 @@
 
   <repositories>
     <repository>
-      <id>central</id> 
-      <name>Maven repository</name> 
-      <url>http://repo1.maven.org/maven2</url> 
-    </repository>
-    <repository>
       <id>scala-tools.org</id>
       <name>Scala-tools Maven2 Repository</name>
       <url>http://scala-tools.org/repo-releases</url>
-    </repository>
-    <repository>
-      <id>jetlang</id>
-      <name>Jetlang</name>
-      <url>http://jetlang.googlecode.com/svn/repo/</url>
-    </repository>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
-    </repository>
-    <repository>
-      <id>coda-hale-repo</id>
-      <name>Coda Hale's Repo</name>
-      <url>http://repo.codahale.com/</url>
     </repository>
     <repository>
       <id>boundary-public</id>

--- a/pom.xml
+++ b/pom.xml
@@ -51,12 +51,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.4</version>
+      <version>1.7.5</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.4</version>
+      <version>1.7.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/scala/overlock/threadpool/InstrumentedThreadPoolExecutor.scala
+++ b/src/main/scala/overlock/threadpool/InstrumentedThreadPoolExecutor.scala
@@ -18,8 +18,7 @@ package overlock.threadpool
 import java.util.concurrent._
 import com.yammer.metrics._
 import scala._
-import core._
-import com.codahale.logula.Logging
+import org.slf4j.LoggerFactory
 
 class InstrumentedThreadPoolExecutor(path : String,
     name : String, 
@@ -30,7 +29,8 @@ class InstrumentedThreadPoolExecutor(path : String,
     workQueue : BlockingQueue[Runnable],
     factory : ThreadFactory) extends 
     ThreadPoolExecutor(corePoolSize,maximumPoolSize,keepAliveTime,unit,workQueue,factory) with 
-    Instrumented with Logging {
+    Instrumented {
+  protected lazy val log = LoggerFactory.getLogger(getClass)
   val requestRate = metrics.meter("request", "requests", path + "." + name, TimeUnit.SECONDS)
   val rejectedRate = metrics.meter("rejected", "requests", path + "." + name, TimeUnit.SECONDS)
   val executionTimer = metrics.timer("execution", path + "." + name)

--- a/src/main/scala/overlock/threadpool/NamedThreadFactory.scala
+++ b/src/main/scala/overlock/threadpool/NamedThreadFactory.scala
@@ -17,7 +17,7 @@ package overlock.threadpool
 
 import java.util.concurrent._
 import atomic._
-import com.codahale.logula.Logging
+import org.slf4j.LoggerFactory
 
 /**
  * Based off of the NamedThreadFactory in cassandra
@@ -33,13 +33,14 @@ class NamedThreadFactory(val name : String, val priority : Int = Thread.NORM_PRI
   }
 }
 
-class ErrorLoggedThread(r : Runnable, threadName : String) extends Thread(r, threadName) with Logging {
+class ErrorLoggedThread(r : Runnable, threadName : String) extends Thread(r, threadName) {
+  protected lazy val log = LoggerFactory.getLogger(getClass)
   override def run {
     try {
       super.run
     } catch {
       case e : Throwable => 
-        log.error(e, "Exception was thrown in thread " + threadName)
+        log.error("Exception was thrown in thread " + threadName, e)
         throw e
     }
   }

--- a/src/test/scala/overlock/threadpool/InstrumentedThreadPoolExecutorSpec.scala
+++ b/src/test/scala/overlock/threadpool/InstrumentedThreadPoolExecutorSpec.scala
@@ -3,7 +3,7 @@ package overlock.threadpool
 import org.specs._
 import java.util.concurrent.atomic._
 
-class InstrumentedThreadPoolExecutorSpec extends Specification {
+class InstrumentedThreadPoolExecutorSpec extends SpecificationWithJUnit {
   "InstrumentedThreadPoolExecutor" should {
     "basically work" in {
       val pool = ThreadPool.instrumentedFixed("threadpool", "1", 1).asInstanceOf[InstrumentedThreadPoolExecutor]


### PR DESCRIPTION
To prevent downstream dependencies from depending on a particular
logging implementation, switch from logula to slf4j for logging. Upgrade
to a more recent version of the Metrics library. Make sure the
InstrumentedThreadPoolExecutorSpec testcase runs with Maven.
