### PR TITLE
Bring Overlock into the present with sbt and Scala 2.11.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 project/boot/*
 project/build/target/*
+project/target/*
 target/*
 lib_managed/*
 .idea/

--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,12 @@ val scalaVsn = "2.11.6"
 resolvers += "Boundary Public Repo" at "http://maven.boundary.com/artifactory/repo"
 
 libraryDependencies ++= Seq(
-  "com.yammer.metrics" % "metrics-core" % "2.2.0",
-  "com.yammer.metrics" % "metrics-scala_2.9.1" % "2.2.0",
+  "nl.grons" %% "metrics-scala" % "3.4.0",
   "com.boundary" % "high-scale-lib" % "1.0.5",
-  "org.scala-tools.testing" % "specs_2.9.1" % "1.6.9",
-  "junit" % "junit" % "4.8.2" % "test",
   "org.slf4j" % "slf4j-api" % "1.7.6",
+
+  "org.specs2" %% "specs2" % "2.4.15" % "test",
+  "junit" % "junit" % "4.8.2" % "test",
   "org.slf4j" % "slf4j-simple" % "1.7.6" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,19 @@
+val scalaVsn = "2.11.6"
+
+resolvers += "Boundary Public Repo" at "http://maven.boundary.com/artifactory/repo"
+
+libraryDependencies ++= Seq(
+  "com.yammer.metrics" % "metrics-core" % "2.2.0",
+  "com.yammer.metrics" % "metrics-scala_2.9.1" % "2.2.0",
+  "com.boundary" % "high-scale-lib" % "1.0.5",
+  "org.scala-tools.testing" % "specs_2.9.1" % "1.6.9",
+  "junit" % "junit" % "4.8.2" % "test",
+  "org.slf4j" % "slf4j-api" % "1.7.6",
+  "org.slf4j" % "slf4j-simple" % "1.7.6" % "test"
+)
+
+lazy val overlock = (project in file(".")).
+  settings(
+    name := "overlock",
+    scalaVersion := scalaVsn
+  )

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.boundary</groupId>
-  <artifactId>overlock-scala_2.9.1</artifactId>
+  <artifactId>overlock-scala_2.11</artifactId>
   <version>0.8.7-SNAPSHOT</version>
 
   <name>overlock</name>
@@ -10,21 +10,16 @@
   <packaging>jar</packaging>
 
   <properties>
-    <scala.version>2.9.1</scala.version>
+    <scala.version>2.11.6</scala.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.6</slf4j.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>com.yammer.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>2.2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yammer.metrics</groupId>
-      <artifactId>metrics-scala_${scala.version}</artifactId>
-      <version>2.2.0</version>
+      <groupId>nl.grons</groupId>
+      <artifactId>metrics-scala_2.11</artifactId>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.boundary</groupId>
@@ -32,9 +27,14 @@
       <version>1.0.5</version>
     </dependency>
     <dependency>
-      <groupId>org.scala-tools.testing</groupId>
-      <artifactId>specs_${scala.version}</artifactId>
-      <version>1.6.9</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.specs2</groupId>
+      <artifactId>specs2_2.11</artifactId>
+      <version>2.4.15</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -42,11 +42,6 @@
       <artifactId>junit</artifactId>
       <version>4.8.2</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/main/scala/overlock/atomicmap/AtomicMap.scala
+++ b/src/main/scala/overlock/atomicmap/AtomicMap.scala
@@ -16,8 +16,8 @@
 
 package overlock.atomicmap
 
-import scala.collection.mutable.ConcurrentMap
-import java.util.concurrent.{ConcurrentMap => JConcurrentMap, ConcurrentSkipListMap, ConcurrentHashMap}
+import scala.collection.concurrent.Map
+import java.util.concurrent.{ConcurrentMap, ConcurrentSkipListMap, ConcurrentHashMap}
 import java.util.Comparator
 import org.cliffc.high_scale_lib._
 
@@ -55,7 +55,7 @@ object AtomicMap {
   }
 }
 
-class AtomicMap[A,B](u : => JConcurrentMap[A,Any]) extends ConcurrentMap[A,B] {
+class AtomicMap[A,B](u : => ConcurrentMap[A,Any]) extends Map[A,B] {
   val under = u
 
   override def empty = new AtomicMap[A,B](u)

--- a/src/main/scala/overlock/atomicmap/AtomicMap.scala
+++ b/src/main/scala/overlock/atomicmap/AtomicMap.scala
@@ -16,9 +16,11 @@
 
 package overlock.atomicmap
 
-import scala.collection.concurrent.Map
-import java.util.concurrent.{ConcurrentMap, ConcurrentSkipListMap, ConcurrentHashMap}
 import java.util.Comparator
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap, ConcurrentSkipListMap}
+
+import scala.collection.concurrent.Map
+
 import org.cliffc.high_scale_lib._
 
 object AtomicMap {

--- a/src/main/scala/overlock/atomicmap/AtomicNavigableMap.scala
+++ b/src/main/scala/overlock/atomicmap/AtomicNavigableMap.scala
@@ -16,8 +16,7 @@
 
 package overlock.atomicmap
 
-import java.util.concurrent.{ConcurrentNavigableMap, ConcurrentSkipListMap}
-import java.util.{NavigableMap, NavigableSet}
+import java.util.concurrent.ConcurrentNavigableMap
 
 class AtomicNavigableMap[A,B](u : => ConcurrentNavigableMap[A,Any]) extends AtomicMap[A,B](u) {
 

--- a/src/main/scala/overlock/atomicmap/OneShotThunk.scala
+++ b/src/main/scala/overlock/atomicmap/OneShotThunk.scala
@@ -16,9 +16,6 @@
 
 package overlock.atomicmap
 
-import java.util.concurrent._
-import locks._
-
 object OneShotThunk {
   def unapply[A](ost : OneShotThunk[A]) : Option[A] = {
     ost.value match {

--- a/src/main/scala/overlock/atomicmap/ThroughputTest.scala
+++ b/src/main/scala/overlock/atomicmap/ThroughputTest.scala
@@ -16,9 +16,9 @@
 
 package overlock.atomicmap
 
+import java.util.Random
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.atomic._
-import java.util.Random
 
 import scala.collection.mutable.Map
 import scala.math._

--- a/src/main/scala/overlock/atomicmap/ThroughputTest.scala
+++ b/src/main/scala/overlock/atomicmap/ThroughputTest.scala
@@ -16,11 +16,11 @@
 
 package overlock.atomicmap
 
-import scala.collection.mutable.ConcurrentMap
-import java.util.{concurrent => juc}
-import juc.atomic._
-import juc.CyclicBarrier
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.atomic._
 import java.util.Random
+
+import scala.collection.mutable.Map
 import scala.math._
 
 object ThroughputTest {
@@ -35,7 +35,7 @@ object ThroughputTest {
 }
 
 abstract class ThroughputTest {
-  def createMap[A,B](size : Int) : ConcurrentMap[A,B]
+  def createMap[A,B](size : Int) : Map[A,B]
   
   val threadMin = 1
   val threadMax = 8
@@ -111,7 +111,7 @@ abstract class ThroughputTest {
   }
 }
 
-class ThroughputThread(map : ConcurrentMap[String,String], keys : Array[String], startBarrier : CyclicBarrier) extends Thread {
+class ThroughputThread(map : Map[String,String], keys : Array[String], startBarrier : CyclicBarrier) extends Thread {
   val random = new Random()
   val operations = new AtomicLong(0)
   val writes = new AtomicLong(0)

--- a/src/main/scala/overlock/lock/Lock.scala
+++ b/src/main/scala/overlock/lock/Lock.scala
@@ -67,7 +67,7 @@ class Lock {
   }
 }
 
-sealed class LockResult(private val success: Boolean) {
+sealed case class LockResult(private val success: Boolean) {
   def orElse[U](f : => U) {
     if (!success) {
       f
@@ -78,7 +78,7 @@ sealed class LockResult(private val success: Boolean) {
 }
 
 object LockResult {
-  val TRUE = new LockResult(true)
-  val FALSE = new LockResult(false)
+  val TRUE = LockResult(true)
+  val FALSE = LockResult(false)
 }
 

--- a/src/main/scala/overlock/threadpool/InstrumentedThreadPoolExecutor.scala
+++ b/src/main/scala/overlock/threadpool/InstrumentedThreadPoolExecutor.scala
@@ -16,6 +16,7 @@
 package overlock.threadpool
 
 import java.util.concurrent._
+
 import nl.grons.metrics.scala._
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/overlock/threadpool/InstrumentedThreadPoolExecutor.scala
+++ b/src/main/scala/overlock/threadpool/InstrumentedThreadPoolExecutor.scala
@@ -16,8 +16,7 @@
 package overlock.threadpool
 
 import java.util.concurrent._
-import com.yammer.metrics._
-import scala._
+import nl.grons.metrics.scala._
 import org.slf4j.LoggerFactory
 
 class InstrumentedThreadPoolExecutor(path : String,
@@ -29,10 +28,11 @@ class InstrumentedThreadPoolExecutor(path : String,
     workQueue : BlockingQueue[Runnable],
     factory : ThreadFactory) extends 
     ThreadPoolExecutor(corePoolSize,maximumPoolSize,keepAliveTime,unit,workQueue,factory) with 
-    Instrumented {
+    InstrumentedBuilder {
+  val metricRegistry = new com.codahale.metrics.MetricRegistry()
   protected lazy val log = LoggerFactory.getLogger(getClass)
-  val requestRate = metrics.meter("request", "requests", path + "." + name, TimeUnit.SECONDS)
-  val rejectedRate = metrics.meter("rejected", "requests", path + "." + name, TimeUnit.SECONDS)
+  val requestRate = metrics.meter("requests", path + "." + name)
+  val rejectedRate = metrics.meter("rejected requests", path + "." + name)
   val executionTimer = metrics.timer("execution", path + "." + name)
   val queueGauge = metrics.gauge("queue size", path + "." + name)(getQueue.size)
   val threadGauge = metrics.gauge("threads", path + "." + name)(getPoolSize)

--- a/src/main/scala/overlock/threadpool/NamedThreadFactory.scala
+++ b/src/main/scala/overlock/threadpool/NamedThreadFactory.scala
@@ -16,7 +16,8 @@
 package overlock.threadpool
 
 import java.util.concurrent._
-import atomic._
+import java.util.concurrent.atomic._
+
 import org.slf4j.LoggerFactory
 
 /**

--- a/src/test/scala/overlock/atomicmap/AtomicMapSpec.scala
+++ b/src/test/scala/overlock/atomicmap/AtomicMapSpec.scala
@@ -14,51 +14,50 @@ abstract class AtomicMapSpec extends SpecificationWithJUnit {
     
     "be a full concurrentmap implementation" in {
       "getOrElseUpdate" in {
-        map.getOrElseUpdate("blah", 1) must beEqualTo(1)
-        map.getOrElseUpdate("blah", 2) must beEqualTo(1)
+        map.getOrElseUpdate("getOrElseUpdate", 1) must beEqualTo(1)
+        map.getOrElseUpdate("getOrElseUpdate", 2) must beEqualTo(1)
       }
 
       "replace(k,v)" in {
-        map.replace("blah", 1) must beNone
-        map.put("blah", 1)
-        map.replace("blah", 2) must beSome(1)
+        map.replace("replace(k,v)", 1) must beNone
+        map.put("replace(k,v)", 1)
+        map.replace("replace(k,v)", 2) must beSome(1)
       }
 
       "replace(k, o, n)" in {
-        map.replace("blah", 2, 1) must beFalse
-        map.put("blah", 1)
-        println("map " + map)
-        map.replace("blah", 1, 2) must beTrue
-        map("blah") must beEqualTo(2)
+        map.replace("replace(k, o, n)", 2, 1) must beFalse
+        map.put("replace(k, o, n)", 1)
+        map.replace("replace(k, o, n)", 1, 2) must beTrue
+        map("replace(k, o, n)") must beEqualTo(2)
       }
 
       "remove" in {
-        map.put("blah", 1)
-        map.remove("blah", 2) must beFalse
-        map.remove("blah", 1) must beTrue
-        map.get("blah") must beNone
+        map.put("remove", 1)
+        map.remove("remove", 2) must beFalse
+        map.remove("remove", 1) must beTrue
+        map.get("remove") must beNone
       }
 
       "putIfAbsent" in {
-        map.putIfAbsent("blah", 1) must beNone
-        map.putIfAbsent("blah", 2) must beSome(1)
-        map.putIfAbsent("derp", 3) must beNone
+        map.putIfAbsent("putIfAbsent-first", 1) must beNone
+        map.putIfAbsent("putIfAbsent-first", 2) must beSome(1)
+        map.putIfAbsent("putIfAbsent-second", 3) must beNone
       }
 
       "-=" in {
-        map.put("herp", 1)
-        map -= "herp"
-        map.get("herp") must beNone
+        map.put("-=", 1)
+        map -= "-="
+        map.get("-=") must beNone
       }
 
       "+=" in {
-        map += (("herp", 1))
-        map.get("herp") must beSome(1)
+        map += "+=" -> 1
+        map.get("+=") must beSome(1)
       }
 
       "iterator" in {
-        map.put("herp", 1)
-        map.put("derp", 2)
+        map.put("iterator-first", 1)
+        map.put("iterator-second", 2)
         
         val otherMap = createMap[String,Int]
 
@@ -66,19 +65,19 @@ abstract class AtomicMapSpec extends SpecificationWithJUnit {
           otherMap.put(key,value)
         }
         
-        otherMap.get("herp") must beSome(1)
-        otherMap.get("derp") must beSome(2)
+        otherMap.get("iterator-first") must beSome(1)
+        otherMap.get("iterator-second") must beSome(2)
       }
       
       "get" in {
-        map.put("herp", 5)
-        map.get("herp") must beSome(5)
+        map.put("get", 5)
+        map.get("get") must beSome(5)
       }
       
       "return a new empty" in {
-        map.put("herp", 1)
+        map.put("return a new empty", 1)
         val emptyMap = map.empty
-        emptyMap.get("herp") must beNone
+        emptyMap.get("return a new empty") must beNone
       }
     }
     
@@ -88,13 +87,13 @@ abstract class AtomicMapSpec extends SpecificationWithJUnit {
       val threads = for (i <- (0 to 5)) yield {
         new Thread {
           override def run {
-            map.getOrElseUpdate("blah", {Thread.sleep(100); counter.incrementAndGet})
+            map.getOrElseUpdate("evaluate op only once", {Thread.sleep(100); counter.incrementAndGet})
           }
         }
       }
       threads.foreach(_.start)
       threads.foreach(_.join)
-      map("blah") must beEqualTo(1)
+      map("evaluate op only once") must beEqualTo(1)
       counter.get must beEqualTo(1)
     }
   }

--- a/src/test/scala/overlock/atomicmap/AtomicMapSpec.scala
+++ b/src/test/scala/overlock/atomicmap/AtomicMapSpec.scala
@@ -1,8 +1,10 @@
 package overlock.atomicmap
 
-import org.specs2.mutable._
-import scala.collection.concurrent.Map
 import java.util.concurrent.atomic._
+
+import scala.collection.concurrent.Map
+
+import org.specs2.mutable._
 
 abstract class AtomicMapSpec extends SpecificationWithJUnit {
   def createMap[A,B] : Map[A,B]

--- a/src/test/scala/overlock/atomicmap/AtomicMapSpec.scala
+++ b/src/test/scala/overlock/atomicmap/AtomicMapSpec.scala
@@ -1,20 +1,19 @@
 package overlock.atomicmap
 
-import org.specs._
-import scala.collection.mutable.ConcurrentMap
-import scala.collection.JavaConversions._
+import org.specs2.mutable._
+import scala.collection.concurrent.Map
 import java.util.concurrent.atomic._
 
 abstract class AtomicMapSpec extends SpecificationWithJUnit {
-  def createMap[A,B] : ConcurrentMap[A,B]
+  def createMap[A,B] : Map[A,B]
   
   "AtomicMap" should {
     val map = createMap[String,Int]
     
     "be a full concurrentmap implementation" in {
       "getOrElseUpdate" in {
-        map.getOrElseUpdate("blah", 1) must ==(1)
-        map.getOrElseUpdate("blah", 2) must ==(1)
+        map.getOrElseUpdate("blah", 1) must beEqualTo(1)
+        map.getOrElseUpdate("blah", 2) must beEqualTo(1)
       }
 
       "replace(k,v)" in {
@@ -24,17 +23,17 @@ abstract class AtomicMapSpec extends SpecificationWithJUnit {
       }
 
       "replace(k, o, n)" in {
-        map.replace("blah", 2, 1) must ==(false)
+        map.replace("blah", 2, 1) must beFalse
         map.put("blah", 1)
         println("map " + map)
-        map.replace("blah", 1, 2) must ==(true)
-        map("blah") must ==(2)
+        map.replace("blah", 1, 2) must beTrue
+        map("blah") must beEqualTo(2)
       }
 
       "remove" in {
         map.put("blah", 1)
-        map.remove("blah", 2) must ==(false)
-        map.remove("blah", 1) must ==(true)
+        map.remove("blah", 2) must beFalse
+        map.remove("blah", 1) must beTrue
         map.get("blah") must beNone
       }
 
@@ -93,8 +92,8 @@ abstract class AtomicMapSpec extends SpecificationWithJUnit {
       }
       threads.foreach(_.start)
       threads.foreach(_.join)
-      map("blah") must ==(1)
-      counter.get must ==(1)
+      map("blah") must beEqualTo(1)
+      counter.get must beEqualTo(1)
     }
   }
 }

--- a/src/test/scala/overlock/lock/LockSpec.scala
+++ b/src/test/scala/overlock/lock/LockSpec.scala
@@ -9,11 +9,7 @@ class LockSpec extends SpecificationWithJUnit {
     "acquire a lock with tryLock if it's not already held" in {
       val lock = new Lock
 
-      lock.tryWriteLock {
-        true must beTrue
-      }.orElse {
-        failure("Welp. You should have locked.")
-      }
+      lock.tryWriteLock(()) must beEqualTo(LockResult.TRUE)
     }
 
     "not acquire a lock with tryLock if it's already held" in {
@@ -33,11 +29,7 @@ class LockSpec extends SpecificationWithJUnit {
       holdUp.await()
 
       try {
-        lock.tryWriteLock {
-          failure("Shouldn't be able to get here")
-        }.orElse {
-          true must beTrue
-        }
+        lock.tryWriteLock(()) must beEqualTo(LockResult.FALSE)
       } finally {
         done.set(true)
       }
@@ -63,12 +55,7 @@ class LockSpec extends SpecificationWithJUnit {
 
       readers.foreach(t => t.start())
       holdUp.await()
-      lock.tryWriteLock {
-        failure("Shouldn't be able to write lock")
-      }.orElse {
-        // Success
-        true must beTrue
-      }
+      lock.tryWriteLock(()) must beEqualTo(LockResult.FALSE)
     }
 
     "be able to held by a single writer" in {
@@ -90,12 +77,7 @@ class LockSpec extends SpecificationWithJUnit {
       writer.start()
       holdUp.await()
 
-      lock.tryReadLock {
-        failure("Shouldn't be able to acquire a read lock while writing")
-      }.orElse {
-        // Great Success!
-        true must beTrue
-      }
+      lock.tryWriteLock(()) must beEqualTo(LockResult.FALSE)
     }
   }
 }

--- a/src/test/scala/overlock/lock/LockSpec.scala
+++ b/src/test/scala/overlock/lock/LockSpec.scala
@@ -1,6 +1,6 @@
 package overlock.lock
 
-import org.specs._
+import org.specs2.mutable._
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -12,7 +12,7 @@ class LockSpec extends SpecificationWithJUnit {
       lock.tryWriteLock {
         true must beTrue
       }.orElse {
-        fail("Welp. You should have locked.")
+        failure("Welp. You should have locked.")
       }
     }
 
@@ -34,7 +34,7 @@ class LockSpec extends SpecificationWithJUnit {
 
       try {
         lock.tryWriteLock {
-          fail("Shouldn't be able to get here")
+          failure("Shouldn't be able to get here")
         }.orElse {
           true must beTrue
         }
@@ -56,7 +56,7 @@ class LockSpec extends SpecificationWithJUnit {
               holdUp.countDown()
               while (!done.get) { /*spin, spin, spin*/}
             }.orElse {
-              fail("I want to lock but it didn't let me")
+              failure("I want to lock but it didn't let me")
             }
           }
         }
@@ -64,7 +64,7 @@ class LockSpec extends SpecificationWithJUnit {
       readers.foreach(t => t.start())
       holdUp.await()
       lock.tryWriteLock {
-        fail("Shouldn't be able to write lock")
+        failure("Shouldn't be able to write lock")
       }.orElse {
         // Success
         true must beTrue
@@ -82,7 +82,7 @@ class LockSpec extends SpecificationWithJUnit {
             holdUp.countDown()
             while (!done.get) { /*keep on swimming, keep on swimming*/ }
           }.orElse {
-            fail("Couldn't acquire a write lock")
+            failure("Couldn't acquire a write lock")
           }
         }
       }
@@ -91,7 +91,7 @@ class LockSpec extends SpecificationWithJUnit {
       holdUp.await()
 
       lock.tryReadLock {
-        fail("Shouldn't be able to acquire a read lock while writing")
+        failure("Shouldn't be able to acquire a read lock while writing")
       }.orElse {
         // Great Success!
         true must beTrue

--- a/src/test/scala/overlock/lock/LockSpec.scala
+++ b/src/test/scala/overlock/lock/LockSpec.scala
@@ -1,8 +1,9 @@
 package overlock.lock
 
-import org.specs2.mutable._
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
+
+import org.specs2.mutable._
 
 class LockSpec extends SpecificationWithJUnit {
   "Lock" should {

--- a/src/test/scala/overlock/lock/SpinLockSpec.scala
+++ b/src/test/scala/overlock/lock/SpinLockSpec.scala
@@ -1,9 +1,10 @@
 package overlock.lock
 
-import org.specs2.mutable._
-import java.util.{concurrent => juc}
-import juc.atomic._
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic._
+import java.util.{concurrent => juc}
+
+import org.specs2.mutable._
 
 class SpinLockSpec extends SpecificationWithJUnit {
   "SpinLock" should {

--- a/src/test/scala/overlock/lock/SpinLockSpec.scala
+++ b/src/test/scala/overlock/lock/SpinLockSpec.scala
@@ -1,6 +1,6 @@
 package overlock.lock
 
-import org.specs._
+import org.specs2.mutable._
 import java.util.{concurrent => juc}
 import juc.atomic._
 import java.util.concurrent.CountDownLatch
@@ -85,14 +85,14 @@ class SpinLockSpec extends SpecificationWithJUnit {
       readers.foreach(_.join)
       writers.foreach(_.join)
 
-      writes.get must ==(numWriters)
-      reads.get must ==(numReaders)
+      writes.get must beEqualTo(numWriters)
+      reads.get must beEqualTo(numReaders)
 
-      writersInCS.get must ==(0)
-      readersInCS.get must ==(0)
-      rwFlag.get must ==(false)
-      wrFlag.get must ==(false)
-      wwFlag.get must ==(false)
+      writersInCS.get must beEqualTo(0)
+      readersInCS.get must beEqualTo(0)
+      rwFlag.get must beFalse
+      wrFlag.get must beFalse
+      wwFlag.get must beFalse
     }
     
     "lock out multiple writers" in {
@@ -129,9 +129,9 @@ class SpinLockSpec extends SpecificationWithJUnit {
       threads.foreach(_.start)
       threads.foreach(_.join)
 
-      writes.get must ==(numWriters)
-      writerInCS.get must ==(false)
-      csViolated.get must ==(false)
+      writes.get must beEqualTo(numWriters)
+      writerInCS.get must beFalse
+      csViolated.get must beFalse
     }
   }
 }

--- a/src/test/scala/overlock/threadpool/ElasticBlockingQueueSpec.scala
+++ b/src/test/scala/overlock/threadpool/ElasticBlockingQueueSpec.scala
@@ -1,7 +1,6 @@
 package overlock.threadpool
 
-import org.specs._
-import java.util.concurrent._
+import org.specs2.mutable._
 
 class ElasticBlockingQueueSpec extends SpecificationWithJUnit {
   "ElasticBlockingQueue" should {
@@ -13,7 +12,7 @@ class ElasticBlockingQueueSpec extends SpecificationWithJUnit {
       pool.execute(new Runnable {
         def run = Thread.sleep(100)
       })
-      pool.getPoolSize must ==(2)
+      pool.getPoolSize must beEqualTo(2)
     }
     
     "switch to queueing behavior" in {
@@ -23,8 +22,8 @@ class ElasticBlockingQueueSpec extends SpecificationWithJUnit {
           def run = Thread.sleep(100)
         })
       }
-      pool.getPoolSize must ==(2)
-      pool.getQueue.size must ==(3)
+      pool.getPoolSize must beEqualTo(2)
+      pool.getQueue.size must beEqualTo(3)
     }
   }
 }

--- a/src/test/scala/overlock/threadpool/InstrumentedThreadPoolExecutorSpec.scala
+++ b/src/test/scala/overlock/threadpool/InstrumentedThreadPoolExecutorSpec.scala
@@ -1,7 +1,8 @@
 package overlock.threadpool
 
-import org.specs2.mutable._
 import java.util.concurrent.atomic._
+
+import org.specs2.mutable._
 
 class InstrumentedThreadPoolExecutorSpec extends SpecificationWithJUnit {
   "InstrumentedThreadPoolExecutor" should {

--- a/src/test/scala/overlock/threadpool/InstrumentedThreadPoolExecutorSpec.scala
+++ b/src/test/scala/overlock/threadpool/InstrumentedThreadPoolExecutorSpec.scala
@@ -1,6 +1,6 @@
 package overlock.threadpool
 
-import org.specs._
+import org.specs2.mutable._
 import java.util.concurrent.atomic._
 
 class InstrumentedThreadPoolExecutorSpec extends SpecificationWithJUnit {
@@ -14,13 +14,13 @@ class InstrumentedThreadPoolExecutorSpec extends SpecificationWithJUnit {
         }
       })
       Thread.sleep(100)
-      counter.get must ==(1)
-      pool.threadGauge.value must ==(1)
-      pool.queueGauge.value must ==(0)
-      pool.requestRate.count must ==(1)
-      pool.rejectedRate.count must ==(0)
-      pool.executionTimer.count must ==(1)
-      pool.activeThreadGauge.value must ==(0)
+      counter.get must beEqualTo(1)
+      pool.threadGauge.value must beEqualTo(1)
+      pool.queueGauge.value must beEqualTo(0)
+      pool.requestRate.count must beEqualTo(1)
+      pool.rejectedRate.count must beEqualTo(0)
+      pool.executionTimer.count must beEqualTo(1)
+      pool.activeThreadGauge.value must beEqualTo(0)
     }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.8.7-SNAPSHOT"


### PR DESCRIPTION
Hey there! I was looking at the `AtomicMap` and found it interesting but was disappointed about the binary incompatibility. So I updated things!

You could probably take this PR as-is but it contains some unfinished business with sbt. I wanted to ask you all more about how your lifecycle management works so I can port that over to sbt so you can drop maven with the Scala plugin, which I think is more painful to use than sbt!

Are there any developers who can comment on your release process (basically, the `mvn` commands you invoke) so I can help complete the sbt transition?
